### PR TITLE
Fix code coverage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,17 @@
+/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.(ts|tsx)$': 'ts-jest',
+  },
+  collectCoverage: true,
+  collectCoverageFrom: [
+    '**/src/**'
+  ],
+  coveragePathIgnorePatterns: [
+    "enums",
+    "providers",
+    "testing"
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -20,22 +20,5 @@
   "dependencies": {
     "@types/node": "^17.0.21",
     "typescript": "4.1.6"
-  },
-  "jest": {
-    "verbose": false,
-    "silent": true,
-    "transform": {
-      "^.+\\.tsx?$": "ts-jest"
-    },
-    "collectCoverage": true,
-    "collectCoverageFrom": [
-      "**/lib/**",
-      "**/src/**"
-    ],
-    "coveragePathIgnorePatterns": [
-      "enums",
-      "providers",
-      "testing"
-    ]
   }
 }

--- a/packages/asu-core/__tests__/aws/services/secrets-manager.service.spec.ts
+++ b/packages/asu-core/__tests__/aws/services/secrets-manager.service.spec.ts
@@ -1,9 +1,8 @@
 import "reflect-metadata";
 import { AWSError, Request, SecretsManager, Service } from "aws-sdk";
-
-import { SecretsManagerProvider } from "../../../lib/aws/providers/secrets-manager.provider";
+import { SecretsManagerProvider } from "../../../src/aws/providers/secrets-manager.provider";
 import { Mock } from '../../../src/testing/mock-provider';
-import { AwsSecretKey, AwsSecretName, EnvironmentVariable, SecretsManagerService } from "../../../lib/asu-core";
+import { AwsSecretKey, AwsSecretName, EnvironmentVariable, SecretsManagerService } from "../../../src/asu-core";
 
 describe('SecretsManagerService', () => {
     const expectedRegion = 'us-east-1';
@@ -20,7 +19,7 @@ describe('SecretsManagerService', () => {
         const secretBody = { $response: null };
         if (secret !== undefined) {
             secretBody['SecretString'] = secret
-        };
+        }
         secretResponseObject.promise.mockResolvedValue(secretBody);
         awsSecretsManager.getSecretValue.mockReturnValue(secretResponseObject);
     };


### PR DESCRIPTION
Move jest config to own file in root dir
Fix imports in `SecretsManagerService` tests to use `src` instead of `lib`