### PR TITLE
Add getAgreement functionality

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,6 +11,7 @@ module.exports = {
   ],
   coveragePathIgnorePatterns: [
     "enums",
+    "errors",
     "providers",
     "testing"
   ]

--- a/lambdas/adobe-sign-api/src/agreements-controller.ts
+++ b/lambdas/adobe-sign-api/src/agreements-controller.ts
@@ -3,11 +3,19 @@ import { AdobeSignService } from "adobe-sign";
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { container } from "tsyringe";
 
-export const getAgreement = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
-    let service = container.resolve(AdobeSignService);
-    let agreement = await service.getAgreement(event.pathParameters.id);
+function formatResponse(statusCode: number, payload: string): APIGatewayProxyResult {
     return {
-        statusCode: 200,
-        body: "agreement: " + JSON.stringify(agreement)
-    };
+        statusCode,
+        body: payload
+    }
+}
+
+export const getAgreement = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+    try {
+        const service = container.resolve(AdobeSignService);
+        const agreement = await service.getAgreement(event.pathParameters.id);
+        return formatResponse(200, JSON.stringify(agreement))
+    } catch (error) {
+        return formatResponse(error.statusCode ?? 500, JSON.stringify({error: error.message}));
+    }
 }

--- a/lambdas/adobe-sign-api/src/agreements-controller.ts
+++ b/lambdas/adobe-sign-api/src/agreements-controller.ts
@@ -16,6 +16,9 @@ export const getAgreement = async (event: APIGatewayProxyEvent): Promise<APIGate
         const agreement = await service.getAgreement(event.pathParameters.id);
         return formatResponse(200, JSON.stringify(agreement))
     } catch (error) {
-        return formatResponse(error.statusCode ?? 500, JSON.stringify({error: error.message}));
+        let errorCode = error.statusCode === 404 ? 404 : 500;
+        let errorMessage = errorCode === 404 ? `Agreement with ID: ${event.pathParameters.id} does not exist.`
+            : 'Internal Service Error';
+        return formatResponse(errorCode, JSON.stringify({error: errorMessage}));
     }
 }

--- a/packages/adobe-sign/__tests__/apis/adobe-sign-api.spec.ts
+++ b/packages/adobe-sign/__tests__/apis/adobe-sign-api.spec.ts
@@ -18,7 +18,7 @@ describe('AdobeSignAPI', () => {
     }
 
     describe('getAgreement', () => {
-        it('should be called with the given id and return Agreement object', async () => {
+        it('should make a GET request with the given id and return Agreement object', async () => {
             // Arrange
             let { adobeApi, mockAxios } = setup();
             const mockData = {
@@ -31,13 +31,12 @@ describe('AdobeSignAPI', () => {
             }
 
             mockAxios.get.mockResolvedValue({data: mockData});
-            let apiSpy = jest.spyOn(adobeApi, 'getAgreement')
 
             // Act
             let result = await adobeApi.getAgreement(mockData.id);
 
             // Assert
-            expect(apiSpy).toBeCalledWith(mockData.id);
+            expect(mockAxios.get).toBeCalledWith('/agreements/' + mockData.id);
             expect(result).toMatchObject(mockData);
         });
 

--- a/packages/adobe-sign/__tests__/apis/adobe-sign-api.spec.ts
+++ b/packages/adobe-sign/__tests__/apis/adobe-sign-api.spec.ts
@@ -30,7 +30,7 @@ describe('AdobeSignAPI', () => {
                 hasFormFieldData: true,
             }
 
-            mockAxios.get.mockResolvedValue(Promise.resolve({data: mockData}));
+            mockAxios.get.mockReturnValue(Promise.resolve({data: mockData}));
             let apiSpy = jest.spyOn(adobeApi as any, 'getAgreement')
 
             // Act

--- a/packages/adobe-sign/__tests__/apis/adobe-sign-api.spec.ts
+++ b/packages/adobe-sign/__tests__/apis/adobe-sign-api.spec.ts
@@ -1,0 +1,75 @@
+import "reflect-metadata";
+import { AdobeSignApi } from '../../src/apis/adobe-sign-api';
+import {AxiosProvider, SecretsManagerService} from "asu-core";
+import {Mock} from "asu-core/src/testing/mock-provider";
+import {Axios} from "axios";
+import {InternalApiError} from "../../src/apis/errors/internal-api-error";
+import {AdobeApiError} from "../../src/apis/errors/adobe-api-error";
+
+describe('AdobeSignAPI', () => {
+    function setup() {
+        const secretsManagerService = Mock(new SecretsManagerService(null));
+        const mockAxios = Mock(new Axios());
+        const axiosProvider = Mock(new AxiosProvider())
+        axiosProvider.resolve.mockReturnValue(mockAxios);
+        const adobeApi = new AdobeSignApi(secretsManagerService, axiosProvider);
+
+        return { secretsManagerService, adobeApi, mockAxios };
+    }
+
+    describe('getAgreement', () => {
+        it('should be called with the given id and return Agreement object', async () => {
+            // Arrange
+            let { adobeApi, mockAxios } = setup();
+            const mockData = {
+                id: 'CBJCHBCAABAAN24SWUnGHW-o_NaT5i3O5lKuHiccQ2GP',
+                name: '[DEMO USE ONLY] Agreement Test 001',
+                groupId: 'CBJCHBCAABAACnRhBD9pKDAfZ55583n-4WOlwlvI_RGM',
+                type: 'AGREEMENT',
+                status: 'SIGNED',
+                hasFormFieldData: true,
+            }
+
+            mockAxios.get.mockResolvedValue(Promise.resolve({data: mockData}));
+            let apiSpy = jest.spyOn(adobeApi as any, 'getAgreement')
+
+            // Act
+            let result = await adobeApi.getAgreement(mockData.id);
+
+            // Assert
+            expect(apiSpy).toBeCalledWith(mockData.id);
+            expect(result).toMatchObject(mockData);
+        });
+
+        it('should throw an InternalApiError if the HTTP client cannot be created', async () => {
+            // Arrange
+            let { adobeApi, secretsManagerService } = setup();
+            secretsManagerService.getSecret.mockReturnValue(Promise.reject('Test error'));
+
+            // Assert
+            await expect(async () => {
+                // Act
+                await adobeApi.getAgreement('123');
+            }).rejects.toThrow(InternalApiError);
+        })
+
+        it('should throw an AdobeApiError if API request failed', async () => {
+            // Arrange
+            let { adobeApi, mockAxios } = setup();
+            mockAxios.get.mockReturnValue(Promise.reject({
+                response: {
+                    status: 401,
+                    data: {
+                        message: 'Test error'
+                    }
+                }
+            }));
+
+            // Assert
+            await expect(async () => {
+                // Act
+                await adobeApi.getAgreement('123');
+            }).rejects.toThrow(AdobeApiError);
+        })
+    });
+});

--- a/packages/adobe-sign/__tests__/apis/adobe-sign-api.spec.ts
+++ b/packages/adobe-sign/__tests__/apis/adobe-sign-api.spec.ts
@@ -30,8 +30,8 @@ describe('AdobeSignAPI', () => {
                 hasFormFieldData: true,
             }
 
-            mockAxios.get.mockReturnValue(Promise.resolve({data: mockData}));
-            let apiSpy = jest.spyOn(adobeApi as any, 'getAgreement')
+            mockAxios.get.mockResolvedValue({data: mockData});
+            let apiSpy = jest.spyOn(adobeApi, 'getAgreement')
 
             // Act
             let result = await adobeApi.getAgreement(mockData.id);
@@ -44,7 +44,7 @@ describe('AdobeSignAPI', () => {
         it('should throw an InternalApiError if the HTTP client cannot be created', async () => {
             // Arrange
             let { adobeApi, secretsManagerService } = setup();
-            secretsManagerService.getSecret.mockReturnValue(Promise.reject('Test error'));
+            secretsManagerService.getSecret.mockRejectedValue('Test error');
 
             // Assert
             await expect(async () => {
@@ -56,14 +56,14 @@ describe('AdobeSignAPI', () => {
         it('should throw an AdobeApiError if API request failed', async () => {
             // Arrange
             let { adobeApi, mockAxios } = setup();
-            mockAxios.get.mockReturnValue(Promise.reject({
+            mockAxios.get.mockRejectedValue({
                 response: {
                     status: 401,
                     data: {
                         message: 'Test error'
                     }
                 }
-            }));
+            });
 
             // Assert
             await expect(async () => {

--- a/packages/adobe-sign/__tests__/services/adobe-sign.service.spec.ts
+++ b/packages/adobe-sign/__tests__/services/adobe-sign.service.spec.ts
@@ -5,7 +5,7 @@ import { AdobeSignService } from '../../src/services/adobe-sign.service';
 
 describe('AdobeSignService', () => {
     function setup() {
-        const adobeApi = new AdobeSignApi(null);
+        const adobeApi = new AdobeSignApi(null, null);
         const service = new AdobeSignService(adobeApi);
 
         return { service, adobeApi };
@@ -15,12 +15,17 @@ describe('AdobeSignService', () => {
         it('should call the AdobeSignApi with the given id', async () => {
             // Arrange
             let { service, adobeApi } = setup();
-            let expectedId = '8e902a9e-1e2a-4bc5-8399-adaf191fe76f';
-            let agreement = new Agreement();
+            let expectedId = 'CBJCHBCAABAAN24SWUnGHW-o_NaT5i3O5lKuHiccQ2GP';
+            let agreement = new Agreement({
+                id: expectedId,
+                name: '[DEMO USE ONLY] Agreement Test 001',
+                groupId: 'CBJCHBCAABAACnRhBD9pKDAfZ55583n-4WOlwlvI_RGM',
+                type: 'AGREEMENT',
+                status: 'SIGNED',
+                hasFormFieldData: true,
+            });
 
-            agreement.id = expectedId;
-
-            let apiSpy = jest.spyOn(adobeApi, 'getAgreement').mockResolvedValue(agreement);
+            let apiSpy = jest.spyOn(adobeApi as any, 'getAgreement').mockResolvedValue(agreement);
 
             // Act
             let result = await service.getAgreement(expectedId);

--- a/packages/adobe-sign/__tests__/services/adobe-sign.service.spec.ts
+++ b/packages/adobe-sign/__tests__/services/adobe-sign.service.spec.ts
@@ -25,7 +25,7 @@ describe('AdobeSignService', () => {
                 hasFormFieldData: true,
             });
 
-            let apiSpy = jest.spyOn(adobeApi as any, 'getAgreement').mockResolvedValue(agreement);
+            let apiSpy = jest.spyOn(adobeApi, 'getAgreement').mockResolvedValue(agreement);
 
             // Act
             let result = await service.getAgreement(expectedId);

--- a/packages/adobe-sign/package.json
+++ b/packages/adobe-sign/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "asu-core": "^1.0.0",
+    "axios": "^0.26.1",
     "tsyringe": "^4.6.0"
   }
 }

--- a/packages/adobe-sign/src/apis/adobe-sign-api.ts
+++ b/packages/adobe-sign/src/apis/adobe-sign-api.ts
@@ -14,13 +14,11 @@ export class AdobeSignApi {
     private async getHttpClient(): Promise<Axios> {
         if (!this.httpClient) {
             try {
-                console.log('Fetching integration key from secrets manager');
                 const integrationKey = await this.secretsManagerService.getSecret(
                     AwsSecretName.AdobeSign,
                     AwsSecretKey.AdobeSignIntegrationKey
                 );
 
-                console.log('Creating axios instance');
                 this.httpClient = this.axiosProvider.resolve({
                     //@todo get Base URL from cache/secretsManager
                     baseURL: 'https://api.na3.adobesign.com/api/rest/v6',
@@ -39,7 +37,6 @@ export class AdobeSignApi {
     public async getAgreement(id: string): Promise<Agreement> {
         try {
             const httpClient = await this.getHttpClient();
-            console.log('Fetching agreement from AdobeSign');
             const agreementRes = await httpClient.get(`/agreements/${id}`);
             return new Agreement(agreementRes.data);
         } catch ( err ) {

--- a/packages/adobe-sign/src/apis/adobe-sign-api.ts
+++ b/packages/adobe-sign/src/apis/adobe-sign-api.ts
@@ -46,10 +46,12 @@ export class AdobeSignApi {
 
     private static handleAdobeApiErrors(error: ApiError|AxiosError) {
         if (error instanceof ApiError) {
-            // If already an ApiError (e.g. InternalApiError), forward error
+            // If already an ApiError (e.g. InternalApiError), log and forward error
+            console.log(error.message);
             throw error;
         }
 
-        throw new AdobeApiError(error.response.status, error.response.data.message)
+        console.log('AdobeSignApi error: ' + error.response.data.message);
+        throw new AdobeApiError(error.response.status, error.response.data.message);
     }
 }

--- a/packages/adobe-sign/src/apis/adobe-sign-api.ts
+++ b/packages/adobe-sign/src/apis/adobe-sign-api.ts
@@ -1,19 +1,58 @@
-import { AwsSecretKey, AwsSecretName, SecretsManagerService } from "asu-core";
+import {AwsSecretKey, AwsSecretName, AxiosProvider, SecretsManagerService} from "asu-core";
 import { injectable } from "tsyringe";
 import { Agreement } from "../models/agreement";
+import {Axios, AxiosError} from "axios";
+import {ApiError} from "./errors/api-error";
+import {AdobeApiError} from "./errors/adobe-api-error";
+import {InternalApiError} from "./errors/internal-api-error";
 
 @injectable()
 export class AdobeSignApi {
-    constructor(private secretsManagerService: SecretsManagerService) {}
+    private httpClient: Axios;
+    constructor(private secretsManagerService: SecretsManagerService, private axiosProvider: AxiosProvider) {}
+
+    private async getHttpClient(): Promise<Axios> {
+        if (!this.httpClient) {
+            try {
+                console.log('Fetching integration key from secrets manager');
+                const integrationKey = await this.secretsManagerService.getSecret(
+                    AwsSecretName.AdobeSign,
+                    AwsSecretKey.AdobeSignIntegrationKey
+                );
+
+                console.log('Creating axios instance');
+                this.httpClient = this.axiosProvider.resolve({
+                    //@todo get Base URL from cache/secretsManager
+                    baseURL: 'https://api.na3.adobesign.com/api/rest/v6',
+                    headers: {
+                        Authorization : `Bearer ${integrationKey}`
+                    }
+                });
+            } catch ( err ) {
+                throw new InternalApiError('Could not initialize AdobeSign HTTP client. ' + err.message);
+            }
+        }
+
+        return this.httpClient;
+    }
 
     public async getAgreement(id: string): Promise<Agreement> {
-        const integrationKey = await this.secretsManagerService.getSecret(
-            AwsSecretName.AdobeSign,
-            AwsSecretKey.AdobeSignIntegrationKey
-        );
-        const agreement = new Agreement();
-        agreement.id = id;
+        try {
+            const httpClient = await this.getHttpClient();
+            console.log('Fetching agreement from AdobeSign');
+            const agreementRes = await httpClient.get(`/agreements/${id}`);
+            return new Agreement(agreementRes.data);
+        } catch ( err ) {
+            AdobeSignApi.handleAdobeApiErrors(err);
+        }
+    }
 
-        return agreement;
+    private static handleAdobeApiErrors(error: ApiError|AxiosError) {
+        if (error instanceof ApiError) {
+            // If already an ApiError (e.g. InternalApiError), forward error
+            throw error;
+        }
+
+        throw new AdobeApiError(error.response.status, error.response.data.message)
     }
 }

--- a/packages/adobe-sign/src/apis/errors/adobe-api-error.ts
+++ b/packages/adobe-sign/src/apis/errors/adobe-api-error.ts
@@ -1,0 +1,10 @@
+import {ApiError} from "./api-error";
+
+export class AdobeApiError extends ApiError {
+  statusCode = 500;
+  constructor(statusCode: number, message: string){
+    super('AdobeSign API Error - ' + message);
+    this.statusCode = statusCode;
+    Object.setPrototypeOf(this, AdobeApiError.prototype);
+  }
+}

--- a/packages/adobe-sign/src/apis/errors/adobe-api-error.ts
+++ b/packages/adobe-sign/src/apis/errors/adobe-api-error.ts
@@ -1,8 +1,7 @@
 import {ApiError} from "./api-error";
 
 export class AdobeApiError extends ApiError {
-  statusCode = 500;
-  constructor(statusCode: number, message: string){
+  constructor(public statusCode: number, message: string){
     super('AdobeSign API Error - ' + message);
     this.statusCode = statusCode;
     Object.setPrototypeOf(this, AdobeApiError.prototype);

--- a/packages/adobe-sign/src/apis/errors/api-error.ts
+++ b/packages/adobe-sign/src/apis/errors/api-error.ts
@@ -1,0 +1,8 @@
+export abstract class ApiError extends Error{
+  abstract statusCode: number;
+
+  protected constructor(message: string){
+    super(message);
+    Object.setPrototypeOf(this, ApiError.prototype);
+  }
+}

--- a/packages/adobe-sign/src/apis/errors/internal-api-error.ts
+++ b/packages/adobe-sign/src/apis/errors/internal-api-error.ts
@@ -1,0 +1,9 @@
+import {ApiError} from "./api-error";
+
+export class InternalApiError extends ApiError {
+  statusCode = 500;
+  constructor(message: string){
+    super('Internal API Error - ' + message);
+    Object.setPrototypeOf(this, InternalApiError.prototype);
+  }
+}

--- a/packages/adobe-sign/src/models/agreement.ts
+++ b/packages/adobe-sign/src/models/agreement.ts
@@ -15,12 +15,12 @@ export class Agreement {
     status: string;
     hasFormFieldData: boolean;
 
-    constructor({id, name, groupId, type, status, hasFormFieldData}: ResponseData) {
-        this.id = id;
-        this.name = name;
-        this.groupId = groupId;
-        this.type = type;
-        this.status = status;
-        this.hasFormFieldData = hasFormFieldData;
+    constructor(data: ResponseData) {
+        this.id = data.id;
+        this.name = data.name;
+        this.groupId = data.groupId;
+        this.type = data.type;
+        this.status = data.status;
+        this.hasFormFieldData = data.hasFormFieldData;
     }
 }

--- a/packages/adobe-sign/src/models/agreement.ts
+++ b/packages/adobe-sign/src/models/agreement.ts
@@ -1,12 +1,26 @@
-export class Agreement {
-    displayDate: string;
-    esign: boolean;
-    groupId: string;
-    hidden: boolean;
-    latestVersionId: string;
-    name: string;
+export interface ResponseData {
     id: string;
-    parentId: string;
-    status: string;
+    name: string;
+    groupId: string;
     type: string;
+    status: string;
+    hasFormFieldData: boolean;
+}
+
+export class Agreement {
+    id: string;
+    name: string;
+    groupId: string;
+    type: string;
+    status: string;
+    hasFormFieldData: boolean;
+
+    constructor({id, name, groupId, type, status, hasFormFieldData}: ResponseData) {
+        this.id = id;
+        this.name = name;
+        this.groupId = groupId;
+        this.type = type;
+        this.status = status;
+        this.hasFormFieldData = hasFormFieldData;
+    }
 }

--- a/packages/asu-core/package.json
+++ b/packages/asu-core/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "aws-sdk": "^2.1093.0",
+    "axios": "^0.26.1",
     "tsyringe": "^4.6.0"
   }
 }

--- a/packages/asu-core/src/asu-core.ts
+++ b/packages/asu-core/src/asu-core.ts
@@ -6,5 +6,8 @@ export * from "./aws/enums/aws-secret-key";
 
 export * from "./enums/environment-variable";
 
+// providers
+export * from "./http/providers/axios.provider";
+
 // services
 export * from "./aws/services/secrets-manager.service";

--- a/packages/asu-core/src/http/providers/axios.provider.ts
+++ b/packages/asu-core/src/http/providers/axios.provider.ts
@@ -1,0 +1,7 @@
+import {Axios, AxiosRequestConfig, default as axios} from "axios";
+
+export class AxiosProvider {
+  public resolve(config: AxiosRequestConfig): Axios {
+    return axios.create(config);
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3103,6 +3103,13 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.10.0.tgz#a17b3a8ea811060e74d47d306122400ad4497ae2"
   integrity sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==
 
+axios@^0.26.1:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.1.tgz#1ede41c51fcf51bbbd6fd43669caaa4f0495aaa9"
+  integrity sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==
+  dependencies:
+    follow-redirects "^1.14.8"
+
 babel-eslint@^10.0.2:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.1.0.tgz#6968e568a910b78fb3779cdd8b6ac2f479943232"
@@ -5212,6 +5219,11 @@ flush-write-stream@^1.0.0:
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
+
+follow-redirects@^1.14.8:
+  version "1.14.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
+  integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==
 
 for-each@^0.3.3:
   version "0.3.3"


### PR DESCRIPTION
- Add AxiosProvider to `asu-core` package
- Add working request to AdobeSign API to fetch Agreement objects in `adobe-sign` package
- Add `InternalApiError` and `AdobeApiError` classes to differentiate between errors specific to our internal resources and Adobe API errors
- Add test cases for `AdobeSignAPI`/`getAgreement`
- Update `adobeApi` signature in the `AdobeSignService` test to include AxiosProvider constructor argument