### PR TITLE
SIGN-138: Remove internally managed ids

### DIFF
--- a/aws-resources/database/serverless.yml
+++ b/aws-resources/database/serverless.yml
@@ -10,10 +10,10 @@ resources:
       Properties:
         TableName: ${opt:stage}-templates
         AttributeDefinitions:
-          - AttributeName: id
+          - AttributeName: adobeSignId
             AttributeType: S
         KeySchema:
-          - AttributeName: id
+          - AttributeName: adobeSignId
             KeyType: HASH
         ProvisionedThroughput:
           ReadCapacityUnits: 1
@@ -23,14 +23,32 @@ resources:
       Properties:
         TableName: ${opt:stage}-agreements
         AttributeDefinitions:
-          - AttributeName: id
+          - AttributeName: adobeSignId
+            AttributeType: S
+          - AttributeName: asuriteId
+            AttributeType: S
+          - AttributeName: status
             AttributeType: S
         KeySchema:
-          - AttributeName: id
+          - AttributeName: adobeSignId
             KeyType: HASH
         ProvisionedThroughput:
           ReadCapacityUnits: 1
           WriteCapacityUnits: 1
+        GlobalSecondaryIndexes:
+          - IndexName: asuriteId-status-index
+            KeySchema:
+              - AttributeName: asuriteId
+                KeyType: HASH
+              - AttributeName: status
+                KeyType: RANGE
+            Projection:
+              ProjectionType: INCLUDE
+              NonKeyAttributes:
+                - adobeSignTemplateId
+            ProvisionedThroughput:
+              ReadCapacityUnits: 1
+              WriteCapacityUnits: 1
   Outputs:
     TemplatesTableARN:
       Description: "ARN of the TemplatesTable"

--- a/packages/adobe-sign/__tests__/repos/base.repo.spec.ts
+++ b/packages/adobe-sign/__tests__/repos/base.repo.spec.ts
@@ -6,7 +6,7 @@ import { PutItemOutput, GetItemOutput } from "aws-sdk/lib/dynamodb/types";
 import { AWSError } from "aws-sdk/lib/error";
 import { Template } from "../../src/models/asu/template";
 
-describe('TemplatesRepo', () => {
+describe('BaseRepo', () => {
   const expectedStage = "dev";
 
   function setup() {
@@ -53,21 +53,20 @@ describe('TemplatesRepo', () => {
       await expect(repo.create(template)).rejects.toThrow(expectedError);
     });
 
-    it('should set id on given item, put the item, and return the modified item', async () => {
+    it('should put and return the item', async () => {
       // Arrange
       const { repo, dynamo } = setup();
-      const template = new Template();
+      const expectedTemplate = new Template();
       const expectedTable = `${expectedStage}-templates`;
       
       putReturns(dynamo, null);
 
       // Act
-      const result = await repo.create(template);
+      const result = await repo.create(expectedTemplate);
 
       // Assert
-      expect(result.id).toBeDefined();
       expect(dynamo.put.mock.calls[0][0].TableName).toBe(expectedTable);
-      expect(dynamo.put.mock.calls[0][0].Item.id).toBe(result.id);
+      expect(dynamo.put.mock.calls[0][0].Item).toBe(expectedTemplate);
     });
   });
 
@@ -89,7 +88,7 @@ describe('TemplatesRepo', () => {
       const { repo, dynamo } = setup();
       const templateId = "123";
       const table = `${expectedStage}-templates`;
-      const expectedError = new NotFoundError(`No item exists in ${table} with id ${templateId}`);
+      const expectedError = new NotFoundError(`No item exists in ${table} with adobeSignId ${templateId}`);
       
       getReturns(dynamo, {});
 
@@ -101,7 +100,7 @@ describe('TemplatesRepo', () => {
       // Arrange
       const { repo, dynamo } = setup();
       const expectedTemplate = new Template({
-        id: "123",
+        adobeSignId: "123",
         name: "Test Template"
       });
       const expectedTable = `${expectedStage}-templates`;
@@ -109,12 +108,12 @@ describe('TemplatesRepo', () => {
       getReturns(dynamo, {Item: expectedTemplate});
 
       // Act
-      const result = await repo.getTemplateById(expectedTemplate.id);
+      const result = await repo.getTemplateById(expectedTemplate.adobeSignId);
 
       // Assert
       expect(result).toMatchObject(expectedTemplate);
       expect(dynamo.get.mock.calls[0][0].TableName).toBe(expectedTable);
-      expect(dynamo.get.mock.calls[0][0].Key.id).toBe(result.id);
+      expect(dynamo.get.mock.calls[0][0].Key.adobeSignId).toBe(result.adobeSignId);
     });
   });
 });

--- a/packages/adobe-sign/__tests__/repos/templates.repo.spec.ts
+++ b/packages/adobe-sign/__tests__/repos/templates.repo.spec.ts
@@ -28,18 +28,18 @@ describe('TemplatesRepo', () => {
       // Arrange
       const { repo, dynamo } = setup();
       const returnedItem = {
-        id: "123",
+        adobeSignId: "123",
         name: "Test"
       };
 
       getReturns(dynamo, { Item: returnedItem });
 
       // Act 
-      const result = await repo.getTemplateById(returnedItem.id);
+      const result = await repo.getTemplateById(returnedItem.adobeSignId);
 
       // Assert
       expect(result).toBeInstanceOf(Template);
-      expect(result.id).toBe(returnedItem.id);
+      expect(result.adobeSignId).toBe(returnedItem.adobeSignId);
       expect(result.name).toBe(returnedItem.name);
     });
   });

--- a/packages/adobe-sign/__tests__/services/templates.service.spec.ts
+++ b/packages/adobe-sign/__tests__/services/templates.service.spec.ts
@@ -18,9 +18,8 @@ describe('TemplateService', () => {
       const { service, templatesRepo } = setup();
       const expectedTemplateId = "143";
       let expectedTemplate = new Template({
-        id: expectedTemplateId,
-        name: "I-9",
-        adobeSignId: "AJ2"
+        adobeSignId: expectedTemplateId,
+        name: "I-9"
       });
 
       templatesRepo.getTemplateById.mockResolvedValue(expectedTemplate);

--- a/packages/adobe-sign/package.json
+++ b/packages/adobe-sign/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "asu-core": "^1.0.0",
     "axios": "^0.26.1",
-    "tsyringe": "^4.6.0",
-    "uuid": "^8.3.2"
+    "tsyringe": "^4.6.0"
   }
 }

--- a/packages/adobe-sign/src/models/asu/agreement.ts
+++ b/packages/adobe-sign/src/models/asu/agreement.ts
@@ -1,19 +1,16 @@
 import { AgreementStatus } from "../../enums/agreement-status";
-import { ObjectWithId } from "../../repos/base.repo";
 
-export class Agreement implements ObjectWithId {
-  id: string;
-  asuriteId: string;
+export class Agreement {
   adobeSignId: string;
+  asuriteId: string;
   adobeSignTemplateId: string;
   status: AgreementStatus;
   s3Location: string;
 
   constructor(data?: Partial<Agreement>) {
     if (data) {
-      this.id = data.id;
-      this.asuriteId = data.asuriteId;
       this.adobeSignId = data.adobeSignId;
+      this.asuriteId = data.asuriteId;
       this.adobeSignTemplateId = data.adobeSignTemplateId;
       this.status = data.status;
       this.s3Location = data.s3Location;

--- a/packages/adobe-sign/src/models/asu/template.ts
+++ b/packages/adobe-sign/src/models/asu/template.ts
@@ -1,15 +1,13 @@
-import { ObjectWithId } from "../../repos/base.repo";
 import { FormDataMapping } from "./form-data-mapping";
 
-export class Template implements ObjectWithId {
-  id: string;
-  name: string;
+export class Template {
   adobeSignId: string;
+  name: string;
   formDataMappings: FormDataMapping[];
 
   constructor(data?: Partial<Template>) {
     if (data) {
-      this.id = data.id;
+      this.adobeSignId = data.adobeSignId;
       this.name = data.name;
       this.adobeSignId = data.adobeSignId;
       if (data.formDataMappings) {

--- a/packages/adobe-sign/src/repos/agreements.repo.ts
+++ b/packages/adobe-sign/src/repos/agreements.repo.ts
@@ -6,6 +6,6 @@ import { BaseRepo } from "./base.repo";
 @injectable()
 export class AgreementsRepo extends BaseRepo<Agreement> {
   constructor(connectionProvider: DynamoProvider) {
-    super(connectionProvider, 'agreements');
+    super(connectionProvider, 'agreements', 'adobeSignId');
   }
 }

--- a/packages/adobe-sign/src/repos/base.repo.ts
+++ b/packages/adobe-sign/src/repos/base.repo.ts
@@ -1,22 +1,15 @@
 import { DynamoProvider, EnvironmentVariable, NotFoundError } from "asu-core";
-import { v4 as uuid } from "uuid";
 
-export interface ObjectWithId {
-  id: string;
-}
-
-export abstract class BaseRepo<Type> {
+export abstract class BaseRepo<T> {
   protected table: string;
 
-  constructor(protected connectionProvider: DynamoProvider, table: string) {
+  constructor(protected connectionProvider: DynamoProvider, table: string, protected idProp: string) {
     this.table = `${process.env[EnvironmentVariable.Stage]}-${table}`;
   }
 
-  public async create<Type extends ObjectWithId>(item: Type): Promise<Type> {
+  public async create(item: T): Promise<T> {
     try {
       const conn = this.connectionProvider.resolve();
-
-      item.id = uuid();
 
       await conn.put({
         TableName: this.table,
@@ -31,7 +24,7 @@ export abstract class BaseRepo<Type> {
     }
   }
 
-  protected async getById<T>(id: string): Promise<Partial<T>> {
+  protected async getById(id: string): Promise<Partial<T>> {
     let data = null;
     
     try {
@@ -40,7 +33,7 @@ export abstract class BaseRepo<Type> {
       data = await conn.get({
         TableName: this.table,
         Key: {
-          id: id
+          [this.idProp]: id
         }
       }).promise();
     }
@@ -50,7 +43,7 @@ export abstract class BaseRepo<Type> {
     }
 
     if (data.Item === undefined) {
-      throw new NotFoundError(`No item exists in ${this.table} with id ${id}`);
+      throw new NotFoundError(`No item exists in ${this.table} with ${this.idProp} ${id}`);
     }
   
     return data.Item as any as Partial<T>;

--- a/packages/adobe-sign/src/repos/templates.repo.ts
+++ b/packages/adobe-sign/src/repos/templates.repo.ts
@@ -6,11 +6,11 @@ import { BaseRepo } from "./base.repo";
 @injectable()
 export class TemplatesRepo extends BaseRepo<Template> {
   constructor(connectionProvider: DynamoProvider) {
-    super(connectionProvider, 'templates');
+    super(connectionProvider, 'templates', 'adobeSignId');
   }
 
   async getTemplateById(id: string): Promise<Template> {
-    const item = await this.getById<Template>(id);
+    const item = await this.getById(id);
     return new Template(item);
   }
 }


### PR DESCRIPTION
[SIGN-138](https://asudev.jira.com/browse/SIGN-138): We do not need to manage our own uuid internal ids for templates and agreements.  Adobe Sign already manages a unique id and we can use that to simplify some of the data access.