### PR TITLE
SIGN-114 | Auth with CAS Service

### DIFF
--- a/lambdas/adobe-sign-api/src/agreements-controller.ts
+++ b/lambdas/adobe-sign-api/src/agreements-controller.ts
@@ -3,7 +3,7 @@ import "reflect-metadata";
 import {container} from "tsyringe";
 import {AgreementService} from "adobe-sign";
 import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda";
-import {lambdaHandleError, lambdaReturnObject} from "asu-core";
+import {CasService, lambdaHandleError, lambdaRedirect, lambdaReturnObject} from "asu-core";
 
 export const getAgreement = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
   try {
@@ -16,12 +16,14 @@ export const getAgreement = async (event: APIGatewayProxyEvent): Promise<APIGate
 }
 
 export const createSigningUrlAgreement = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
-  try {
-    const service = container.resolve(AgreementService);
-    //@todo CAS auth to retrieve user ID
-    const signingUrlAgreement = await service.createSigningUrlAgreement(event.pathParameters.template_id, 'nleapai');
-    return lambdaReturnObject(signingUrlAgreement);
-  } catch (error) {
-    return lambdaHandleError(error);
-  }
+  const authService = container.resolve(CasService);
+  return await authService.authenticate(event, async () => {
+    try {
+      const service = container.resolve(AgreementService);
+      const signingUrlAgreement = await service.createSigningUrlAgreement(event.pathParameters.template_id);
+      return lambdaRedirect(signingUrlAgreement.signing_url);
+    } catch (apiError) {
+      return lambdaHandleError(apiError);
+    }
+  });
 }

--- a/packages/adobe-sign/__tests__/services/agreement.service.spec.ts
+++ b/packages/adobe-sign/__tests__/services/agreement.service.spec.ts
@@ -89,7 +89,7 @@ describe('AgreementService', () => {
       let {service, adobeApi, casService} = setup();
       jest.spyOn(service, 'createAgreement').mockResolvedValue(new ASUAgreement(fixture.mockAsuAgreementData));
       adobeApi.getAgreementSigningUrls.mockResolvedValue(fixture.mockSigningUrl);
-      casService.getCasUser.mockResolvedValue('testuser');
+      casService.getAuthenticatedUserId.mockResolvedValue('testuser');
       // Act
       let result = await service.createSigningUrlAgreement(fixture.mockTemplateId);
 

--- a/packages/adobe-sign/__tests__/services/agreement.service.spec.ts
+++ b/packages/adobe-sign/__tests__/services/agreement.service.spec.ts
@@ -1,5 +1,5 @@
 import "reflect-metadata";
-import {Mock} from "asu-core";
+import {CasService, Mock} from "asu-core";
 import {AdobeSignApi} from '../../src/apis/adobe-sign/adobe-sign-api';
 import {Agreement} from '../../src/models/adobe-sign/agreement';
 import {AgreementService} from '../../src/services/agreement.service';
@@ -15,9 +15,10 @@ describe('AgreementService', () => {
     const templatesRepo = Mock(new TemplatesRepo(null));
     const agreementsRepo = Mock(new AgreementsRepo(null));
     const usersRepo = Mock(new UsersRepo());
-    const service = new AgreementService(adobeApi, templatesRepo, agreementsRepo, usersRepo);
+    const casService = Mock(new CasService(null));
+    const service = new AgreementService(adobeApi, templatesRepo, agreementsRepo, usersRepo, casService);
 
-    return {service, adobeApi, templatesRepo, agreementsRepo, usersRepo};
+    return {service, adobeApi, templatesRepo, agreementsRepo, usersRepo, casService};
   }
 
   describe('getAgreement', () => {
@@ -85,12 +86,12 @@ describe('AgreementService', () => {
   describe('createSigningUrlAgreement', () => {
     it('should return the id and signing URL of the newly created agreement', async () => {
       // Arrange
-      let {service, adobeApi} = setup();
+      let {service, adobeApi, casService} = setup();
       jest.spyOn(service, 'createAgreement').mockResolvedValue(new ASUAgreement(fixture.mockAsuAgreementData));
       adobeApi.getAgreementSigningUrls.mockResolvedValue(fixture.mockSigningUrl);
-
+      casService.getCasUser.mockResolvedValue('testuser');
       // Act
-      let result = await service.createSigningUrlAgreement(fixture.mockTemplateId, fixture.mockAsuUserId);
+      let result = await service.createSigningUrlAgreement(fixture.mockTemplateId);
 
       // Assert
       expect(result).toMatchObject({

--- a/packages/adobe-sign/src/services/agreement.service.ts
+++ b/packages/adobe-sign/src/services/agreement.service.ts
@@ -8,6 +8,7 @@ import {UsersRepo} from "../repos/users.repo";
 import {AgreementsRepo} from "../repos/agreements.repo";
 import {Agreement as ASUAgreement} from "../models/asu/agreement";
 import {AgreementStatus} from "../enums/agreement-status";
+import {CasService} from "asu-core";
 
 @injectable()
 export class AgreementService {
@@ -15,14 +16,16 @@ export class AgreementService {
       private adobeSignApi: AdobeSignApi,
       private templatesRepo: TemplatesRepo,
       private agreementsRepo: AgreementsRepo,
-      private usersRepo: UsersRepo) {
+      private usersRepo: UsersRepo,
+      private casService: CasService) {
   }
 
   public async getAgreement(id: string): Promise<Agreement> {
     return await this.adobeSignApi.getAgreement(id);
   }
 
-  public async createSigningUrlAgreement(templateId: string, userId: string): Promise<object> {
+  public async createSigningUrlAgreement(templateId: string): Promise<{ agreement_id: string, signing_url: string }> {
+    const userId = await this.casService.getCasUser();
     const agreement = await this.createAgreement(templateId, userId);
     const signingUrl = await this.getAgreementSigningUrls(agreement.adobeSignId);
     return {

--- a/packages/adobe-sign/src/services/agreement.service.ts
+++ b/packages/adobe-sign/src/services/agreement.service.ts
@@ -25,7 +25,7 @@ export class AgreementService {
   }
 
   public async createSigningUrlAgreement(templateId: string): Promise<{ agreement_id: string, signing_url: string }> {
-    const userId = await this.casService.getCasUser();
+    const userId = await this.casService.getAuthenticatedUserId();
     const agreement = await this.createAgreement(templateId, userId);
     const signingUrl = await this.getAgreementSigningUrls(agreement.adobeSignId);
     return {

--- a/packages/asu-core/__tests__/auth/services/cas.service.spec.ts
+++ b/packages/asu-core/__tests__/auth/services/cas.service.spec.ts
@@ -1,0 +1,209 @@
+import "reflect-metadata";
+import {APIGatewayProxyEvent} from "aws-lambda";
+import {Axios} from "axios";
+import {AxiosProvider} from "../../../src/http/providers/axios.provider";
+import {CasService} from "../../../src/auth/services/cas.service";
+import {Mock} from "../../../src/testing/mock-provider";
+import {UnauthenticatedError} from "../../../lib/errors/unauthenticated.error";
+import {EnvironmentVariable} from "../../../src/enums/environment-variable";
+
+describe('CasService', () => {
+  const setup = () => {
+    const mockAxios = Mock(new Axios());
+    const axiosProvider = Mock(new AxiosProvider());
+    axiosProvider.resolve.mockReturnValue(mockAxios);
+    let mockApiEvent: APIGatewayProxyEvent = {
+      body: "",
+      headers: undefined,
+      httpMethod: "",
+      isBase64Encoded: false,
+      multiValueHeaders: undefined,
+      multiValueQueryStringParameters: undefined,
+      path: "",
+      pathParameters: undefined,
+      queryStringParameters: undefined,
+      requestContext: undefined,
+      resource: "",
+      stageVariables: undefined
+    }
+
+    const service = new CasService(axiosProvider);
+
+    return { service, mockAxios, mockApiEvent };
+  };
+
+  describe('authenticate', () => {
+    it('should redirect to CAS login when API event object is missing CAS ticket query parameter', async () => {
+      // Arrange
+      const {service, mockApiEvent} = setup();
+      const mockCallback = jest.fn(async () => {
+        return null;
+      });
+
+      // Act
+      const result = await service.authenticate(mockApiEvent, mockCallback);
+
+      // Assert
+      expect(result.statusCode).toBe(301);
+      expect(result.headers.Location).toBeDefined();
+      expect(mockCallback).not.toHaveBeenCalled();
+    });
+
+    it('should return the callback return value after a successful auth', async () => {
+      // Arrange
+      const {service, mockApiEvent, mockAxios} = setup();
+      mockApiEvent.queryStringParameters = {ticket: 'abc-123'}
+      mockAxios.get.mockResolvedValue({
+        status: 200,
+        data: {
+          serviceResponse: {
+            authenticationSuccess: {
+              user: 'testuser'
+            }
+          }
+        }
+      });
+
+      const expectedCallbackReturn = {
+        statusCode: 200,
+        body: 'success'
+      };
+      const mockCallback = jest.fn(async () => {
+        return expectedCallbackReturn;
+      });
+
+      // Act
+      const result = await service.authenticate(mockApiEvent, mockCallback);
+
+      // Assert
+      expect(mockCallback).toHaveBeenCalled();
+      expect(result).toMatchObject(expectedCallbackReturn);
+    });
+
+    it('should return a 401 after a failed auth', async () => {
+      // Arrange
+      const {service, mockApiEvent, mockAxios} = setup();
+      mockApiEvent.queryStringParameters = {
+        ticket: 'abc-123'
+      }
+      mockAxios.get.mockResolvedValue({
+        status: 200,
+        data: {
+          serviceResponse: {
+            authenticationFailure: {
+              code: "INVALID_TICKET",
+              description: "Ticket 'abc-123' not recognized"
+            }
+          }
+        }
+      });
+
+      const mockCallback = jest.fn(async () => {
+        return null;
+      });
+
+      const expectedResult = {
+        statusCode: 401,
+        body: 'Authentication request failed'
+      };
+
+      // Act
+      const result = await service.authenticate(mockApiEvent, mockCallback);
+
+      // Assert
+      expect(mockCallback).not.toHaveBeenCalled();
+      expect(result).toMatchObject(expectedResult);
+    });
+
+    it('should return a 500 after a non-2** auth response', async () => {
+      // Arrange
+      const {service, mockApiEvent, mockAxios} = setup();
+      mockApiEvent.queryStringParameters = {ticket: 'abc-123'}
+      mockAxios.get.mockRejectedValue({
+        status: 404,
+        data: {
+          "timestamp": "2022-04-05T20:30:09.184+00:00",
+          "status": 404,
+          "error": "Not Found",
+          "message": "No message available",
+          "path": "/cas/bad-route"
+        }
+      });
+
+      const mockCallback = jest.fn(async () => {
+        return null;
+      });
+
+      const expectedResult = {
+        statusCode: 500,
+        body: 'Internal Service Error'
+      };
+
+      // Act
+      const result = await service.authenticate(mockApiEvent, mockCallback);
+
+      // Assert
+      expect(mockCallback).not.toHaveBeenCalled();
+      expect(result).toMatchObject(expectedResult);
+    });
+
+    it('should bypass auth if running in Dev and "skip_auth" query parameter is set to "y"', async () => {
+      // Arrange
+      const {service, mockApiEvent} = setup();
+      process.env[EnvironmentVariable.Stage] = 'dev';
+      mockApiEvent.queryStringParameters = {skip_auth: 'y'}
+      const expectedCallbackReturn = {
+        statusCode: 200,
+        body: 'success'
+      };
+      const mockCallback = jest.fn(async () => {
+        return expectedCallbackReturn;
+      });
+
+      // Act
+      const result = await service.authenticate(mockApiEvent, mockCallback);
+
+      // Assert
+      expect(mockCallback).toHaveBeenCalled();
+      expect(result).toMatchObject(expectedCallbackReturn);
+    });
+  });
+
+  describe('getCasUser', () => {
+    it('should return ASURITE ID string when user is authenticated', async () => {
+      // Arrange
+      const {service, mockApiEvent, mockAxios} = setup();
+      const expectedAuthUser = 'testuser';
+      mockApiEvent.queryStringParameters = {ticket: 'abc-123'}
+      mockAxios.get.mockResolvedValue({
+        status: 200,
+        data: {
+          serviceResponse: {
+            authenticationSuccess: {
+              user: expectedAuthUser
+            }
+          }
+        }
+      });
+      const mockCallback = jest.fn(async () => {
+        return null;
+      });
+
+      // Act
+      await service.authenticate(mockApiEvent, mockCallback);
+      const result = await service.getCasUser();
+
+      // Assert
+      expect(result).toBe(expectedAuthUser);
+    });
+
+    it('should throw when user is not set', async () => {
+      // Arrange
+      const {service} = setup();
+      const expectedError = new UnauthenticatedError('No authenticated user is set in CAS Service');
+
+      // Assert
+      await expect(service.getCasUser()).rejects.toThrow(expectedError);
+    });
+  });
+})

--- a/packages/asu-core/__tests__/auth/services/cas.service.spec.ts
+++ b/packages/asu-core/__tests__/auth/services/cas.service.spec.ts
@@ -169,7 +169,7 @@ describe('CasService', () => {
     });
   });
 
-  describe('getCasUser', () => {
+  describe('getAuthenticatedUserId', () => {
     it('should return ASURITE ID string when user is authenticated', async () => {
       // Arrange
       const {service, mockApiEvent, mockAxios} = setup();
@@ -191,7 +191,7 @@ describe('CasService', () => {
 
       // Act
       await service.authenticate(mockApiEvent, mockCallback);
-      const result = await service.getCasUser();
+      const result = await service.getAuthenticatedUserId();
 
       // Assert
       expect(result).toBe(expectedAuthUser);
@@ -203,7 +203,7 @@ describe('CasService', () => {
       const expectedError = new UnauthenticatedError('No authenticated user is set in CAS Service');
 
       // Assert
-      await expect(service.getCasUser()).rejects.toThrow(expectedError);
+      await expect(service.getAuthenticatedUserId()).rejects.toThrow(expectedError);
     });
   });
 })

--- a/packages/asu-core/__tests__/aws/lambda/error-handler.spec.ts
+++ b/packages/asu-core/__tests__/aws/lambda/error-handler.spec.ts
@@ -1,7 +1,6 @@
 import "reflect-metadata"
-import { NotFoundError } from "../../../src/errors/not-found.error";
 import { lambdaHandleError } from "../../../src/aws/lambda/error-handler";
-import { DataValidationError } from "../../../src/asu-core";
+import { DataValidationError, NotFoundError, UnauthenticatedError } from "../../../src/asu-core";
 
 describe('error-handler', () => {
   describe('lambdaHandleError', () => {
@@ -26,6 +25,18 @@ describe('error-handler', () => {
 
       // Assert
       expect(result.statusCode).toBe(400);
+      expect(result.body).toBe(error.message);
+    });
+
+    it('should set status code to 401 and body to error message when UnauthenticatedError thrown', () => {
+      // Arrange
+      const error = new UnauthenticatedError('Authentication request failed');
+
+      // Act
+      const result = lambdaHandleError(error);
+
+      // Assert
+      expect(result.statusCode).toBe(401);
       expect(result.body).toBe(error.message);
     });
 

--- a/packages/asu-core/src/asu-core.ts
+++ b/packages/asu-core/src/asu-core.ts
@@ -11,6 +11,7 @@ export * from "./http/providers/axios.provider";
 export * from "./aws/providers/dynamo.provider";
 
 // services
+export * from "./auth/services/cas.service";
 export * from "./aws/services/secrets-manager.service";
 
 // testing helpers
@@ -20,6 +21,7 @@ export * from "./testing/mocked-cache-helper-functions";
 // errors
 export * from "./errors/not-found.error";
 export * from "./errors/data-validation.error";
+export * from "./errors/unauthenticated.error";
 
 // functions
 export * from "./aws/lambda/error-handler";

--- a/packages/asu-core/src/auth/services/cas.service.ts
+++ b/packages/asu-core/src/auth/services/cas.service.ts
@@ -1,0 +1,77 @@
+import {singleton} from "tsyringe";
+import {AxiosProvider} from "../../http/providers/axios.provider";
+import {Axios} from "axios";
+import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda";
+import {UnauthenticatedError} from "../../errors/unauthenticated.error";
+import {lambdaRedirect} from "../../aws/lambda/response-handler";
+import {lambdaHandleError} from "../../aws/lambda/error-handler";
+import {EnvironmentVariable} from "../../enums/environment-variable";
+
+const CAS_HOST = 'https://weblogin.asu.edu/cas';
+
+@singleton()
+export class CasService {
+  private httpClient: Axios;
+  private authUser: string;
+
+  constructor(private axiosProvider: AxiosProvider) {
+  }
+
+  private async getHttpClient(): Promise<Axios> {
+    if (!this.httpClient) {
+      this.httpClient = this.axiosProvider.resolve({
+        baseURL: CAS_HOST
+      });
+    }
+
+    return this.httpClient;
+  }
+
+  public async authenticate(event: APIGatewayProxyEvent, callback: ()=>Promise<APIGatewayProxyResult>): Promise<APIGatewayProxyResult> {
+    // Bypass auth on dev
+    if (process.env[EnvironmentVariable.Stage] === 'dev') {
+      if (event.queryStringParameters && event.queryStringParameters.skip_auth === 'y') {
+        this.authUser = 'skipped_auth';
+        return await callback();
+      }
+    }
+
+    try {
+      //@todo get app host from env
+      const serviceUrl = 'https://localhost.asu.edu' + event.path;
+      if (!event.queryStringParameters || !event.queryStringParameters.ticket) {
+        return lambdaRedirect(`${CAS_HOST}/login?service=${serviceUrl}`);
+      }
+
+      const httpClient = await this.getHttpClient();
+      const authResponse = await httpClient.get('/serviceValidate', {
+        params: {
+          format: 'JSON',
+          service: serviceUrl,
+          ticket: event.queryStringParameters.ticket
+        }
+      });
+
+      const {authenticationSuccess, authenticationFailure} = authResponse.data.serviceResponse;
+
+      if (authenticationSuccess) {
+        this.authUser = authenticationSuccess.user;
+        return await callback();
+      }
+
+      console.log(`CasService.authenticate error: ${authenticationFailure.code} - ${authenticationFailure.description}`);
+      return lambdaHandleError(new UnauthenticatedError('Authentication request failed'));
+    } catch (error) {
+      return lambdaHandleError(error);
+    }
+  }
+
+  public async getCasUser(): Promise<string> {
+    if (!this.authUser) {
+      throw new UnauthenticatedError('No authenticated user is set in CAS Service');
+    }
+
+    return this.authUser;
+  }
+
+}

--- a/packages/asu-core/src/auth/services/cas.service.ts
+++ b/packages/asu-core/src/auth/services/cas.service.ts
@@ -12,7 +12,7 @@ const CAS_HOST = 'https://weblogin.asu.edu/cas';
 @singleton()
 export class CasService {
   private httpClient: Axios;
-  private authUser: string;
+  private authenticatedUserId: string;
 
   constructor(private axiosProvider: AxiosProvider) {
   }
@@ -28,10 +28,10 @@ export class CasService {
   }
 
   public async authenticate(event: APIGatewayProxyEvent, callback: ()=>Promise<APIGatewayProxyResult>): Promise<APIGatewayProxyResult> {
-    // Bypass auth on dev
+    // Option to bypass auth on dev, sets user to my ASURITE id
     if (process.env[EnvironmentVariable.Stage] === 'dev') {
       if (event.queryStringParameters && event.queryStringParameters.skip_auth === 'y') {
-        this.authUser = 'skipped_auth';
+        this.authenticatedUserId = 'nleapai';
         return await callback();
       }
     }
@@ -55,7 +55,7 @@ export class CasService {
       const {authenticationSuccess, authenticationFailure} = authResponse.data.serviceResponse;
 
       if (authenticationSuccess) {
-        this.authUser = authenticationSuccess.user;
+        this.authenticatedUserId = authenticationSuccess.user;
         return await callback();
       }
 
@@ -66,12 +66,12 @@ export class CasService {
     }
   }
 
-  public async getCasUser(): Promise<string> {
-    if (!this.authUser) {
+  public async getAuthenticatedUserId(): Promise<string> {
+    if (!this.authenticatedUserId) {
       throw new UnauthenticatedError('No authenticated user is set in CAS Service');
     }
 
-    return this.authUser;
+    return this.authenticatedUserId;
   }
 
 }

--- a/packages/asu-core/src/aws/lambda/error-handler.ts
+++ b/packages/asu-core/src/aws/lambda/error-handler.ts
@@ -1,25 +1,28 @@
 import { APIGatewayProxyResult } from "aws-lambda";
-import { DataValidationError } from "../../asu-core";
-import { NotFoundError } from "../../errors/not-found.error";
+import {DataValidationError, NotFoundError, UnauthenticatedError} from "../../asu-core";
 
 export const lambdaHandleError = (error: any): APIGatewayProxyResult => {
-  if (error instanceof NotFoundError) {
-    return {
-      statusCode: 404,
-      body: error.message
-    }
-  }
-  else if (error instanceof DataValidationError) {
-    return {
-      statusCode: 400,
-      body: error.message
-    }
-  }
-  else {
-    console.log(`lambdaHandleError: Unhandled exception: ${error}`);
-    return {
-      statusCode: 500,
-      body: 'Internal Service Error'
-    }
+  switch(error.constructor) {
+    case NotFoundError:
+      return {
+        statusCode: 404,
+        body: error.message
+      }
+    case DataValidationError:
+      return {
+        statusCode: 400,
+        body: error.message
+      }
+    case UnauthenticatedError:
+      return {
+        statusCode: 401,
+        body: error.message
+      }
+    default:
+      console.log(`lambdaHandleError: Unhandled exception: ${error}`);
+      return {
+        statusCode: 500,
+        body: 'Internal Service Error'
+      }
   }
 }

--- a/packages/asu-core/src/aws/lambda/response-handler.ts
+++ b/packages/asu-core/src/aws/lambda/response-handler.ts
@@ -1,4 +1,4 @@
-import { APIGatewayProxyResult } from "aws-lambda";
+import {APIGatewayProxyResult} from "aws-lambda";
 
 export const lambdaReturn = (response: string, statusCode: number = 200): APIGatewayProxyResult => {
   return {
@@ -13,4 +13,12 @@ export const lambdaReturnObject = (obj: Object, statusCode: number = 200): APIGa
 
 export const lambdaReturnNoContent = (): APIGatewayProxyResult => {
   return lambdaReturn('', 204);
+}
+
+export const lambdaRedirect = (location: string): APIGatewayProxyResult => {
+  return {
+    statusCode: 301,
+    headers: {Location: location},
+    body: ''
+  };
 }

--- a/packages/asu-core/src/errors/unauthenticated.error.ts
+++ b/packages/asu-core/src/errors/unauthenticated.error.ts
@@ -1,0 +1,6 @@
+export class UnauthenticatedError extends Error {
+  constructor(message: string) {
+    super(message);
+    Object.setPrototypeOf(this, UnauthenticatedError.prototype);
+  }
+}


### PR DESCRIPTION
[SIGN-114](https://asudev.jira.com/browse/SIGN-114) | As an ASU Adobe Sign user, I need to sign in with my ASURITE ID before I can access certain agreements to prove my identity.

- Add new CasService with `authenticate` and `getAuthenticatedUserId` methods
- Add `lambdaRedirect` to lambda response-handler to allow redirecting to CAS and AdobeSign ([SIGN-118](https://asudev.jira.com/browse/SIGN-118))
- Update agreements controller/service/tests to implement CasService functionality
- Add Unauthorized error class